### PR TITLE
github.css - darker comments

### DIFF
--- a/themes/github.css
+++ b/themes/github.css
@@ -24,7 +24,7 @@ code.hl-highlighted .string, code.hl-highlighted .string * {color: #d14 !importa
 code.hl-highlighted .comment,
 code.hl-highlighted .comment *,
 code.hl-highlighted .comment .string
-code.hl-highlighted .comment .string * {color: #6B6868 !important;}
+code.hl-highlighted .comment .string * {color: #777777 !important;}
 code.hl-highlighted .string .comment {color: #d14 !important;}
 
 code.hl-highlighted .list.active {display: inline-block; background: #aefff7;}

--- a/themes/github.css
+++ b/themes/github.css
@@ -24,7 +24,7 @@ code.hl-highlighted .string, code.hl-highlighted .string * {color: #d14 !importa
 code.hl-highlighted .comment,
 code.hl-highlighted .comment *,
 code.hl-highlighted .comment .string
-code.hl-highlighted .comment .string * {color: #aaa !important;}
+code.hl-highlighted .comment .string * {color: #6B6868 !important;}
 code.hl-highlighted .string .comment {color: #d14 !important;}
 
 code.hl-highlighted .list.active {display: inline-block; background: #aefff7;}


### PR DESCRIPTION
Hello !

We use this at the Cookbook, and we find that comments are a bit too bright (ping https://github.com/LispCookbook/cl-cookbook/issues/128).

You can see the result of my change here: https://vindarel.github.io/cl-cookbook/web-scraping.html vs https://lispcookbook.github.io/cl-cookbook/web-scraping.html.

Thanks !

ps: the vestigial theme isn't on the demo.